### PR TITLE
Allow for absolute paths to the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gatsby-plugin-codegen
 
-Generate Typescript/Flow definitions from your gatsby queries.
+Generate TypeScript/Flow definitions from your gatsby queries.
 
 Export schema and apollo config file to give autocomplete feature in vscode through apollographql.vscode-apollo (https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo).
 
@@ -58,7 +58,7 @@ const defaultOptions = {
   apolloConfigName: "apollo.config.js",
   addTypename: false,
   excludes: [],
-  localSchemaFile: "schema.json",
+  localSchemaFile: "./schema.json",
   output: "__generated__",
   target: "typescript",
   tagName: "graphql",

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -73,7 +73,7 @@ var defaultOptions = {
     apolloConfigFile: "apollo.config.js",
     addTypename: false,
     excludes: [],
-    localSchemaFile: "schema.json",
+    localSchemaFile: "./schema.json",
     output: "__generated__",
     target: "typescript",
     tagName: "graphql",
@@ -139,7 +139,7 @@ exports.onPostBootstrap = function (_a, userOptions, callback) {
                             }
                             reporter.success("[gatsby-plugin-codegen] saved localSchemaFile: " + localSchemaFile);
                             apolloConfig = path.resolve(process.cwd(), apolloConfigFile);
-                            fs_1.writeFile(apolloConfig, "module.exports = {\n  client: {\n    addTypename: " + addTypename + ",\n    excludes: " + JSON.stringify(excludes) + ",\n    includes: " + JSON.stringify(includes) + ",\n    service: {\n      name: \"gatsbySchema\",\n      localSchemaFile: \"./" + localSchemaFile + "\"\n    },\n    tagName: \"" + tagName + "\"\n  }\n}", "utf8", function (err) { return __awaiter(void 0, void 0, void 0, function () {
+                            fs_1.writeFile(apolloConfig, "module.exports = {\n  client: {\n    addTypename: " + addTypename + ",\n    excludes: " + JSON.stringify(excludes) + ",\n    includes: " + JSON.stringify(includes) + ",\n    service: {\n      name: \"gatsbySchema\",\n      localSchemaFile: \"" + localSchemaFile + "\"\n    },\n    tagName: \"" + tagName + "\"\n  }\n}", "utf8", function (err) { return __awaiter(void 0, void 0, void 0, function () {
                                 var apolloCodegenParams, _a, e_1;
                                 return __generator(this, function (_b) {
                                     switch (_b.label) {

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -37,7 +37,7 @@ const defaultOptions = {
   apolloConfigFile: "apollo.config.js",
   addTypename: false,
   excludes: [],
-  localSchemaFile: "schema.json",
+  localSchemaFile: "./schema.json",
   output: "__generated__",
   target: "typescript",
   tagName: "graphql",
@@ -130,7 +130,7 @@ export const onPostBootstrap: (
     includes: ${JSON.stringify(includes)},
     service: {
       name: "gatsbySchema",
-      localSchemaFile: "./${localSchemaFile}"
+      localSchemaFile: "${localSchemaFile}"
     },
     tagName: "${tagName}"
   }


### PR DESCRIPTION
Thanks for this, it's great work 👍 

The new TypeScript repo is a monorepo, and I need to be able to hardcode the exact place where the schema lives.