### PR TITLE
Add plugins folder to includes config array

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -81,6 +81,7 @@ var defaultOptions = {
     includes: [
         "./src/**/*.tsx",
         "./src/**/*.ts",
+        "./plugins/**/*.js",
         "./node_modules/gatsby-source-contentful/src/*.js",
         "./node_modules/gatsby-transformer-sharp/src/*.js",
         "./node_modules/gatsby-image/src/*.js"

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -45,6 +45,7 @@ const defaultOptions = {
   includes: [
     "./src/**/*.tsx",
     "./src/**/*.ts",
+    "./plugins/**/*.js",
     "./node_modules/gatsby-source-contentful/src/*.js",
     "./node_modules/gatsby-transformer-sharp/src/*.js",
     "./node_modules/gatsby-image/src/*.js"


### PR DESCRIPTION
I found that when a graphql fragment present in a local plugin (within the `plugins` folder) is spread into a query the query works fine, but codegen throws `Unknown fragment` and `Validation of GraphQL query document failed` errors, and fails to generate the types.

This PR adds this folder to the array locations to include.